### PR TITLE
タクシー予約フォームでバリデーションが効くように設定

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,44 +1908,6 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -1953,25 +1915,6 @@
           "dev": true,
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "ms": {
@@ -1987,28 +1930,6 @@
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.5.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
-          "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         }
       }
@@ -2230,6 +2151,22 @@
       "resolved": "https://registry.npmjs.org/@vue/web-component-wrapper/-/web-component-wrapper-1.3.0.tgz",
       "integrity": "sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==",
       "dev": true
+    },
+    "@vuelidate/core": {
+      "version": "2.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@vuelidate/core/-/core-2.0.0-alpha.25.tgz",
+      "integrity": "sha512-8gDZsESacXw++G45yDLB5Fw+tc9fTbRvkL3XFaAhA9Wia6mPp/nS+iLPRrXhwPex5OPqdjre44ZSvMCu7fgpCA==",
+      "requires": {
+        "vue-demi": "^0.11.3"
+      }
+    },
+    "@vuelidate/validators": {
+      "version": "2.0.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/@vuelidate/validators/-/validators-2.0.0-alpha.21.tgz",
+      "integrity": "sha512-Ch+dW2hSWxAv+DcCEbpMVB58rylrCRxrGQMvL1gJKtq2SdrIrvw+IfgGL9VtxLx8U8gqlDiqy7M4Ycu59rUSnA==",
+      "requires": {
+        "vue-demi": "^0.11.3"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -11980,6 +11917,11 @@
         "@vue/shared": "3.2.1"
       }
     },
+    "vue-demi": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.4.tgz",
+      "integrity": "sha512-/3xFwzSykLW2HiiLie43a+FFgNOcokbBJ+fzvFXd0r2T8MYohqvphUyDQ8lbAwzQ3Dlcrb1c9ykifGkhSIAk6A=="
+    },
     "vue-eslint-parser": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.10.0.tgz",
@@ -12063,6 +12005,87 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.5.0",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
+      "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@line/liff": "^2.12.0",
+    "@vuelidate/core": "^2.0.0-alpha.25",
+    "@vuelidate/validators": "^2.0.0-alpha.21",
     "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "vue": "^3.0.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app">
+  <div id="app" class="container">
     <TaxiReserve />
   </div>
 </template>
@@ -41,9 +41,7 @@ export default {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
-  margin-top: 60px;
 }
 
 a {

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@ export default {
   components: {
     TaxiReserve,
   },
-  mounted: function() {
+  mounted: function () {
     this.initVConsole()
   },
   methods: {
@@ -28,11 +28,11 @@ export default {
           },
           onClearLog: function () {
             console.log('vConsole on clearLog')
-          }
+          },
         })
       }
     },
-  }
+  },
 }
 </script>
 
@@ -44,21 +44,6 @@ export default {
   text-align: center;
   color: #2c3e50;
   margin-top: 60px;
-}
-
-h1,
-h2 {
-  font-weight: normal;
-}
-
-ul {
-  list-style-type: none;
-  padding: 0;
-}
-
-li {
-  display: inline-block;
-  margin: 0 10px;
 }
 
 a {

--- a/src/TaxiReserve.vue
+++ b/src/TaxiReserve.vue
@@ -2,7 +2,7 @@
   <div id="taxiReserveWindow" class="hidden">
     <div class="container" align="center">
       <h3>タクシー配車予約</h3>
-      <div id="taxiReserveWindow" class="hidden">
+      <form id="taxiReserveWindow">
         <div class="input-group mb-3">
           <span id="basic-addon1" class="input-group-text">名前</span>
           <input
@@ -23,6 +23,7 @@
             placeholder=""
             aria-label="Phone Number"
             aria-describedby="basic-addon1"
+            required
           />
         </div>
         <div class="col-md-5">
@@ -32,6 +33,7 @@
             class="form-select"
             name="departurePlace"
             @change="getTicketNumber"
+            required
           >
             <option v-for="place in places" :key="place.id" :value="place.id">
               {{ place.name }}
@@ -45,6 +47,7 @@
             class="form-select"
             name="arrivalPlace"
             @change="getTicketNumber"
+            required
           >
             <option v-for="place in places" :key="place.id" :value="place.id">
               {{ place.name }}
@@ -86,7 +89,7 @@
           </button>
         </div>
         <br />
-      </div>
+      </form>
       <div id="MessageWindow" class="hidden" align="center">
         <div class="fw-normal"><div id="message"></div></div>
       </div>
@@ -105,8 +108,10 @@
 <script>
 import liff from '@line/liff'
 import axios from 'axios'
+import useVuelidate from '@vuelidate/core'
+import { required } from '@vuelidate/validators'
+
 export default {
-  name: 'TaxiReserve',
   data() {
     return {
       displayName: '',
@@ -175,6 +180,12 @@ export default {
 
     // 予約の関数
     async reserve() {
+
+      // バリデーション実行
+      const isFormCorrect = await this.v$.$validate()
+      console.log("invalid")
+      if (!isFormCorrect) return
+
       const taxiReservation = {
         userIdToken: liff.getIDToken(),
         userName: this.taxiUserName,
@@ -246,6 +257,15 @@ export default {
       this.isTicketMessageWindow = true
     },
   },
+  setup: () => ({ v$: useVuelidate() }),
+  validations  () {
+    return {
+      taxiUserPhoneNumber: { required },
+      departurePlace: { required },
+      arrivalPlace: { required },
+      numberOfTickets: { required }
+    }
+  }
 }
 </script>
 

--- a/src/TaxiReserve.vue
+++ b/src/TaxiReserve.vue
@@ -1,12 +1,12 @@
 <template>
-  <div id="taxiReserveWindow" class="container" align="center">
-    <h3>タクシー配車予約</h3>
-    <form id="taxiReserveWindow" novalidate>
-      <div class="input-group mb-3">
+  <div id="taxiReserveWindow">
+    <h2 class="text-center mt-5 mb-4">タクシー配車予約</h2>
+    <form class="row row-cols-1 g-3" novalidate>
+      <div class="col input-group">
         <span id="basic-addon1" class="input-group-text">名前</span>
         <input v-model="taxiUserName" type="text" class="form-control" />
       </div>
-      <div class="input-group mb-3">
+      <div class="col input-group">
         <span id="basic-addon1" class="input-group-text">電話番号</span>
         <input
           v-model="taxiUserPhoneNumber"
@@ -16,7 +16,7 @@
         />
         <div class="invalid-feedback">電話番号が入力されていません</div>
       </div>
-      <div class="col-md-5">
+      <div class="col">
         <label class="form-label" for="departurePlace">乗車場所</label>
         <select
           v-model="selectedDeparturePlace"
@@ -31,7 +31,7 @@
         </select>
         <div class="invalid-feedback">選択してください</div>
       </div>
-      <div class="col-md-5">
+      <div class="col">
         <label class="form-label" for="arrivalPlace">降車場所</label>
         <select
           v-model="selectedArrivalPlace"
@@ -46,13 +46,12 @@
         </select>
         <div class="invalid-feedback">選択してください</div>
       </div>
-      <div v-if="isTicketMessageWindow">
-        <span class="text-primary">
+      <div class="col" v-if="isTicketMessageWindow">
+        <div class="alert alert-info">
           必要なチケット枚数は {{ selectedTicketNumber }} 枚です
-        </span>
+        </div>
       </div>
-      <br />
-      <div class="col-md-5">
+      <div class="col">
         <label for="taxiDeparturePlace" class="form-label">乗車人数</label>
         <select
           v-model="taxiNumberOfPassenger"
@@ -66,8 +65,7 @@
         </select>
         <div class="invalid-feedback">選択してください</div>
       </div>
-      <br />
-      <div class="input-group mb-3">
+      <div class="col input-group">
         <span id="basic-addon1" class="input-group-text">同乗者</span>
         <input
           v-model="taxiPassengers"
@@ -78,8 +76,7 @@
           aria-describedby="basic-addon1"
         />
       </div>
-      <br />
-      <div class="input-group mb-3">
+      <div class="col input-group">
         <button
           type="button"
           class="w-100 btn btn-primary btn-lg"
@@ -88,12 +85,8 @@
           予約
         </button>
       </div>
-      <br />
     </form>
-    <div id="MessageWindow" class="hidden" align="center">
-      <div class="fw-normal"><div id="message"></div></div>
-    </div>
-    <footer class="my-5 pt-5 text-muted text-center text-small">
+    <footer class="pt-5 text-muted text-center text-small">
       <p class="mb-1">&copy; 2021 温泉MaaS</p>
       <ul class="list-inline">
         <li class="list-inline-item"><a href="#">プライバシーポリシー</a></li>
@@ -268,7 +261,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .input-group-text {
   min-width: 6em;
 }

--- a/src/TaxiReserve.vue
+++ b/src/TaxiReserve.vue
@@ -1,109 +1,106 @@
 <template>
-  <div id="taxiReserveWindow" class="hidden">
-    <div class="container" align="center">
-      <h3>タクシー配車予約</h3>
-      <form id="taxiReserveWindow" novalidate>
-        <div class="input-group mb-3">
-          <span id="basic-addon1" class="input-group-text">名前</span>
-          <input v-model="taxiUserName" type="text" class="form-control" />
-        </div>
-        <div class="input-group mb-3">
-          <span id="basic-addon1" class="input-group-text">電話番号</span>
-          <input
-            v-model="taxiUserPhoneNumber"
-            type="text"
-            class="form-control"
-            :class="{ 'is-invalid': v$.taxiUserPhoneNumber.$error }"
-          />
-          <div class="invalid-feedback">電話番号が入力されていません</div>
-        </div>
-        <div class="col-md-5">
-          <label class="form-label" for="departurePlace">乗車場所</label>
-          <select
-            v-model="selectedDeparturePlace"
-            class="form-select"
-            name="departurePlace"
-            @change="getTicketNumber"
-            :class="{ 'is-invalid': v$.selectedDeparturePlace.$error }"
-          >
-            <option v-for="place in places" :key="place.id" :value="place.id">
-              {{ place.name }}
-            </option>
-          </select>
-          <div class="invalid-feedback">選択してください</div>
-        </div>
-        <div class="col-md-5">
-          <label class="form-label" for="arrivalPlace">降車場所</label>
-          <select
-            v-model="selectedArrivalPlace"
-            class="form-select"
-            name="arrivalPlace"
-            @change="getTicketNumber"
-            :class="{ 'is-invalid': v$.selectedArrivalPlace.$error }"
-          >
-            <option v-for="place in places" :key="place.id" :value="place.id">
-              {{ place.name }}
-            </option>
-          </select>
-          <div class="invalid-feedback">選択してください</div>
-        </div>
-        <div id="TicketMessageWindow" class="hidden" align="center">
-          <span v-if="isTicketMessageWindow"
-            ><br />必要なチケット枚数 {{ selectedTicketNumber }}枚</span
-          >
-          <span v-if="!isTicketMessageWindow"><br /><br /></span>
-        </div>
-        <br />
-        <div class="col-md-5">
-          <label for="taxiDeparturePlace" class="form-label">乗車人数</label>
-          <select
-            v-model="taxiNumberOfPassenger"
-            class="form-select"
-            :class="{ 'is-invalid': v$.taxiNumberOfPassenger.$error }"
-          >
-            <option value="1" selected>1</option>
-            <option value="2">2</option>
-            <option value="3">3</option>
-            <option value="4">4</option>
-          </select>
-          <div class="invalid-feedback">選択してください</div>
-        </div>
-        <br />
-        <div class="input-group mb-3">
-          <span id="basic-addon1" class="input-group-text">同乗者</span>
-          <input
-            v-model="taxiPassengers"
-            type="text"
-            class="form-control"
-            placeholder=""
-            aria-label="Passengers"
-            aria-describedby="basic-addon1"
-          />
-        </div>
-        <br />
-        <div class="input-group mb-3">
-          <button
-            type="button"
-            class="w-100 btn btn-primary btn-lg"
-            @click="reserve"
-          >
-            予約
-          </button>
-        </div>
-        <br />
-      </form>
-      <div id="MessageWindow" class="hidden" align="center">
-        <div class="fw-normal"><div id="message"></div></div>
+  <div id="taxiReserveWindow" class="container" align="center">
+    <h3>タクシー配車予約</h3>
+    <form id="taxiReserveWindow" novalidate>
+      <div class="input-group mb-3">
+        <span id="basic-addon1" class="input-group-text">名前</span>
+        <input v-model="taxiUserName" type="text" class="form-control" />
       </div>
-      <footer class="my-5 pt-5 text-muted text-center text-small">
-        <p class="mb-1">&copy; 2021 温泉MaaS</p>
-        <ul class="list-inline">
-          <li class="list-inline-item"><a href="#">プライバシーポリシー</a></li>
-          <li class="list-inline-item"><a href="#">規約</a></li>
-          <li class="list-inline-item"><a href="#">サポート</a></li>
-        </ul>
-      </footer>
+      <div class="input-group mb-3">
+        <span id="basic-addon1" class="input-group-text">電話番号</span>
+        <input
+          v-model="taxiUserPhoneNumber"
+          type="text"
+          class="form-control"
+          :class="{ 'is-invalid': v$.taxiUserPhoneNumber.$error }"
+        />
+        <div class="invalid-feedback">電話番号が入力されていません</div>
+      </div>
+      <div class="col-md-5">
+        <label class="form-label" for="departurePlace">乗車場所</label>
+        <select
+          v-model="selectedDeparturePlace"
+          class="form-select"
+          name="departurePlace"
+          @change="getTicketNumber"
+          :class="{ 'is-invalid': v$.selectedDeparturePlace.$error }"
+        >
+          <option v-for="place in places" :key="place.id" :value="place.id">
+            {{ place.name }}
+          </option>
+        </select>
+        <div class="invalid-feedback">選択してください</div>
+      </div>
+      <div class="col-md-5">
+        <label class="form-label" for="arrivalPlace">降車場所</label>
+        <select
+          v-model="selectedArrivalPlace"
+          class="form-select"
+          name="arrivalPlace"
+          @change="getTicketNumber"
+          :class="{ 'is-invalid': v$.selectedArrivalPlace.$error }"
+        >
+          <option v-for="place in places" :key="place.id" :value="place.id">
+            {{ place.name }}
+          </option>
+        </select>
+        <div class="invalid-feedback">選択してください</div>
+      </div>
+      <div v-if="isTicketMessageWindow">
+        <span class="text-primary">
+          必要なチケット枚数は {{ selectedTicketNumber }} 枚です
+        </span>
+      </div>
+      <br />
+      <div class="col-md-5">
+        <label for="taxiDeparturePlace" class="form-label">乗車人数</label>
+        <select
+          v-model="taxiNumberOfPassenger"
+          class="form-select"
+          :class="{ 'is-invalid': v$.taxiNumberOfPassenger.$error }"
+        >
+          <option value="1" selected>1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+        </select>
+        <div class="invalid-feedback">選択してください</div>
+      </div>
+      <br />
+      <div class="input-group mb-3">
+        <span id="basic-addon1" class="input-group-text">同乗者</span>
+        <input
+          v-model="taxiPassengers"
+          type="text"
+          class="form-control"
+          placeholder=""
+          aria-label="Passengers"
+          aria-describedby="basic-addon1"
+        />
+      </div>
+      <br />
+      <div class="input-group mb-3">
+        <button
+          type="button"
+          class="w-100 btn btn-primary btn-lg"
+          @click="reserve"
+        >
+          予約
+        </button>
+      </div>
+      <br />
+    </form>
+    <div id="MessageWindow" class="hidden" align="center">
+      <div class="fw-normal"><div id="message"></div></div>
     </div>
+    <footer class="my-5 pt-5 text-muted text-center text-small">
+      <p class="mb-1">&copy; 2021 温泉MaaS</p>
+      <ul class="list-inline">
+        <li class="list-inline-item"><a href="#">プライバシーポリシー</a></li>
+        <li class="list-inline-item"><a href="#">規約</a></li>
+        <li class="list-inline-item"><a href="#">サポート</a></li>
+      </ul>
+    </footer>
   </div>
 </template>
 
@@ -183,8 +180,10 @@ export default {
     async reserve() {
       // バリデーション実行
       const isFormCorrect = await this.v$.$validate()
-      console.log('バリデーションエラー')
-      if (!isFormCorrect) return
+      if (!isFormCorrect) {
+        console.log('バリデーションエラー')
+        return
+      }
 
       const taxiReservation = {
         userIdToken: liff.getIDToken(),

--- a/src/TaxiReserve.vue
+++ b/src/TaxiReserve.vue
@@ -2,17 +2,10 @@
   <div id="taxiReserveWindow" class="hidden">
     <div class="container" align="center">
       <h3>タクシー配車予約</h3>
-      <form id="taxiReserveWindow">
+      <form id="taxiReserveWindow" novalidate>
         <div class="input-group mb-3">
           <span id="basic-addon1" class="input-group-text">名前</span>
-          <input
-            v-model="taxiUserName"
-            type="text"
-            class="form-control"
-            placeholder=""
-            aria-label="Username"
-            aria-describedby="basic-addon1"
-          />
+          <input v-model="taxiUserName" type="text" class="form-control" />
         </div>
         <div class="input-group mb-3">
           <span id="basic-addon1" class="input-group-text">電話番号</span>
@@ -20,11 +13,9 @@
             v-model="taxiUserPhoneNumber"
             type="text"
             class="form-control"
-            placeholder=""
-            aria-label="Phone Number"
-            aria-describedby="basic-addon1"
-            required
+            :class="{ 'is-invalid': v$.taxiUserPhoneNumber.$error }"
           />
+          <div class="invalid-feedback">電話番号が入力されていません</div>
         </div>
         <div class="col-md-5">
           <label class="form-label" for="departurePlace">乗車場所</label>
@@ -33,12 +24,13 @@
             class="form-select"
             name="departurePlace"
             @change="getTicketNumber"
-            required
+            :class="{ 'is-invalid': v$.selectedDeparturePlace.$error }"
           >
             <option v-for="place in places" :key="place.id" :value="place.id">
               {{ place.name }}
             </option>
           </select>
+          <div class="invalid-feedback">選択してください</div>
         </div>
         <div class="col-md-5">
           <label class="form-label" for="arrivalPlace">降車場所</label>
@@ -47,12 +39,13 @@
             class="form-select"
             name="arrivalPlace"
             @change="getTicketNumber"
-            required
+            :class="{ 'is-invalid': v$.selectedArrivalPlace.$error }"
           >
             <option v-for="place in places" :key="place.id" :value="place.id">
               {{ place.name }}
             </option>
           </select>
+          <div class="invalid-feedback">選択してください</div>
         </div>
         <div id="TicketMessageWindow" class="hidden" align="center">
           <span v-if="isTicketMessageWindow"
@@ -63,12 +56,17 @@
         <br />
         <div class="col-md-5">
           <label for="taxiDeparturePlace" class="form-label">乗車人数</label>
-          <select v-model="taxiNumberOfPassenger" class="form-select" required>
+          <select
+            v-model="taxiNumberOfPassenger"
+            class="form-select"
+            :class="{ 'is-invalid': v$.taxiNumberOfPassenger.$error }"
+          >
             <option value="1" selected>1</option>
             <option value="2">2</option>
             <option value="3">3</option>
             <option value="4">4</option>
           </select>
+          <div class="invalid-feedback">選択してください</div>
         </div>
         <br />
         <div class="input-group mb-3">
@@ -84,7 +82,11 @@
         </div>
         <br />
         <div class="input-group mb-3">
-          <button class="w-100 btn btn-primary btn-lg" @click="reserve">
+          <button
+            type="button"
+            class="w-100 btn btn-primary btn-lg"
+            @click="reserve"
+          >
             予約
           </button>
         </div>
@@ -123,8 +125,8 @@ export default {
       isMessageWindow: false,
       isTicketMessageWindow: false,
       textMessageWindow: '',
-      selectedDeparturePlace: '0',
-      selectedArrivalPlace: '0',
+      selectedDeparturePlace: '',
+      selectedArrivalPlace: '',
       selectedTicketNumber: '',
       ticket: [
         { number: 1 },
@@ -135,7 +137,6 @@ export default {
         { number: 6 },
       ], // 1->2, 1->3, 1->4, 2->3, 2->4, 3->4
       places: [
-        { id: '0', name: '選択してください...' },
         { id: '1', name: '観光会館' },
         { id: '2', name: '○○駅' },
         { id: '3', name: '○○温泉' },
@@ -180,10 +181,9 @@ export default {
 
     // 予約の関数
     async reserve() {
-
       // バリデーション実行
       const isFormCorrect = await this.v$.$validate()
-      console.log("invalid")
+      console.log('バリデーションエラー')
       if (!isFormCorrect) return
 
       const taxiReservation = {
@@ -258,14 +258,14 @@ export default {
     },
   },
   setup: () => ({ v$: useVuelidate() }),
-  validations  () {
+  validations() {
     return {
       taxiUserPhoneNumber: { required },
-      departurePlace: { required },
-      arrivalPlace: { required },
-      numberOfTickets: { required }
+      selectedDeparturePlace: { required },
+      selectedArrivalPlace: { required },
+      taxiNumberOfPassenger: { required },
     }
-  }
+  },
 }
 </script>
 


### PR DESCRIPTION
タクシー予約フォームで以下に対応しました。
- クライアントバリデーションを有効に（ `Vuelidate` ライブラリ利用）
- チケット数表示を目立たせるようにデザインを変更
- Bootstrap CSS のクラスを最適化